### PR TITLE
[chore] Bring back the PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+Pull Request Quick-start
+
+##  Title
+
+Title should follow this format:
+
+`[type]` (Required) `Ticket number` (If one exists) `Title/Description text` (Summary of problem/solution)
+
+`type` must be one of: chore, ops, fix, hotfix, feat, docs, test, poc, lego
+
+Examples:
+
+`[chore] VCH-2023: Adding Pull Request Quick Start Template`
+
+`[hotfix] Fix error in pull request template`
+
+
+## Description
+
+Follow your heart, there are no strict rules here
+
+Do try to give some context on what is the **Problem** and/or what changes were made in your **Solution**


### PR DESCRIPTION
I keep forgetting which `type`s are valid in the PR title, so I selfishly made this template